### PR TITLE
Client impl for real sorting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,8 @@
     "react-redux-form": "^1.16.8",
     "react-scripts": "1.0.13",
     "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "urijs": "^1.19.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { SORT_DATE } from './reducer';
 import BitsContainer from './BitsContainer';
 import CreateBitButton from './CreateBitButton';
 import SortingMenu from './SortingMenu';
@@ -11,9 +10,8 @@ import * as actionCreators from './action_creators';
 class Home extends Component {
   constructor(props, context) {
     super(props, context);
-    const { fetchBits, changeSort } = props;
+    const { fetchBits } = props;
     fetchBits();
-    changeSort(SORT_DATE);
   }
 
   render() {

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -1,4 +1,5 @@
 import {
+    ACTION_CLEAR_BITS,
     ACTION_ADD_BIT,
     ACTION_UPVOTE,
     ACTION_DOWNVOTE,
@@ -16,14 +17,21 @@ import {
     ACTION_RECEIVE_COMMENTS,
     ACTION_REQUEST_CREATE_BIT,
     ACTION_RECEIVE_CREATE_BIT,
+    SORT_DATE,
 } from './reducer';
 import { fetchBit as fetchBitApi, fetchBits as fetchBitsApi, fetchComments as fetchCommentsApi, createBit as createBitApi } from './api_client';
+
+export function clearBits() {
+  return {
+    type: ACTION_CLEAR_BITS
+  };
+}
 
 export function addBit(bit) {
   return {
     type: ACTION_ADD_BIT,
     data: bit
-  }
+  };
 }
 
 export function upvote(bitId) {
@@ -48,10 +56,14 @@ export function resetVote(bitId) {
 }
 
 export function changeSort(sort) {
-  return {
-    type: ACTION_CHANGE_SORT,
-    data: sort
-  }
+  return function(dispatch) {
+    dispatch({
+      type: ACTION_CHANGE_SORT,
+      data: sort
+    });
+    dispatch(clearBits());
+    return dispatch(fetchBits(sort, dispatch));
+  };
 }
 
 export function setMainCharFilters(chars) {
@@ -131,9 +143,9 @@ export function fetchBit(bitId) {
   }
 }
 
-export function fetchBits() {
+export function fetchBits(sort = SORT_DATE) {
   return function(dispatch) {
-    return fetchBitsApi(dispatch);
+    return fetchBitsApi(sort, dispatch);
   }
 }
 

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -56,13 +56,17 @@ export function resetVote(bitId) {
 }
 
 export function changeSort(sort) {
-  return function(dispatch) {
+  return function(dispatch, getState) {
     dispatch({
       type: ACTION_CHANGE_SORT,
       data: sort
     });
-    dispatch(clearBits());
-    return dispatch(fetchBits(sort, dispatch));
+
+    // If we have less than 1 page of bits, we can just sort them client-side.
+    if (getState().get('bits').size >= getState().get('pageSize')) {
+      dispatch(clearBits());
+      dispatch(fetchBits(sort, dispatch));
+    }
   };
 }
 

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -1,35 +1,38 @@
 import { addBit, receiveComments, receiveCreateBit } from './action_creators';
 import { jsonToBit } from './bits_util';
+import { SORT_DATE, SORT_SCORE } from './reducer';
 import { fromJS } from 'immutable';
+import URI from 'urijs';
 
 const BASE_URI = process.env.NODE_ENV === 'production'
     ? 'https://7mgkyv8jyg.execute-api.us-east-1.amazonaws.com/dev'
     : 'http://localhost:3001';
 const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
+const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: 'date', [SORT_SCORE]: 'score' };
 
-export function fetchBits(dispatch) {
+export function fetchBits(sort, dispatch) {
   // TODO(thenuge): Replace concatenation with a proper URI library.
   // TODO(thenuge): Add actions for initiating requests for bit fetching, as well as errors.
-  fetch(BASE_URI + BITS_PATH)
+  fetch(new URI(BASE_URI).path(BITS_PATH).query({ sort: CLIENT_SORT_TO_PARAM[sort] }).toString())
       .then(result => result.json(), error => console.log('Error fetching bits', error))
       .then(response => response.bits.map(bit => dispatch(addBit(jsonToBit(bit)))));
 }
 
 export function fetchBit(bitId, dispatch) {
-  fetch(BASE_URI + BITS_PATH + '/' + bitId)
+  fetch(new URI(BASE_URI).segment([BITS_PATH, bitId]).toString())
       .then(result => result.json(), error => console.log('Error fetching bit: ' + bitId, error))
       .then(response => dispatch(addBit(jsonToBit(response.bit))));
 }
 
 export function fetchComments(bitId, dispatch) {
-  fetch(BASE_URI + BITS_PATH + '/' + bitId + COMMENTS_PATH)
+  fetch(new URI(BASE_URI).segment([BITS_PATH, bitId, COMMENTS_PATH]).toString())
       .then(result => result.json(), error => console.log('Error fetching comments', error))
       .then(response => dispatch(receiveComments(bitId, fromJS(response))));
 }
 
 export function createBit(bit, dispatch) {
-  fetch(BASE_URI + BITS_PATH,
+  fetch(new URI(BASE_URI).path(BITS_PATH).toString(),
       {
         body: JSON.stringify({bit: bit}),
         headers: {

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -1,8 +1,9 @@
-import { Map, Set, fromJS } from 'immutable';
+import { Map, Set, OrderedMap, fromJS } from 'immutable';
 
 window.fromJS = fromJS;
 
 // TODO(thenuge): Some of these constants should probably go elsewhere.
+export const ACTION_CLEAR_BITS = Symbol('ACTION_CLEAR_BITS');
 export const ACTION_UPVOTE = Symbol('ACTION_UPVOTE');
 export const ACTION_DOWNVOTE = Symbol('ACTION_DOWNVOTE');
 export const ACTION_RESET_VOTE = Symbol('ACTION_RESET_VOTE');
@@ -60,9 +61,10 @@ export const FILTER_TAG_COMBOS = Symbol.for('Combos');
 export const FILTER_TAG_ESCAPES = Symbol.for('Escapes');
 
 const INITIAL_STATE = fromJS({
+  bits: OrderedMap(),
   sorting: {
     sorts: [SORT_DATE, SORT_SCORE],
-    currentSort: SORT_SCORE
+    currentSort: SORT_DATE
   },
   filtering: {
     chars: [
@@ -108,6 +110,8 @@ const INITIAL_STATE = fromJS({
 
 export default function(state = INITIAL_STATE, action) {
   switch (action.type) {
+    case ACTION_CLEAR_BITS:
+      return clearBits(state);
     case ACTION_ADD_BIT:
       return addBit(state, action.data);
     case ACTION_UPVOTE:
@@ -150,6 +154,8 @@ export default function(state = INITIAL_STATE, action) {
       return state;
   }
 }
+
+const clearBits = (state = Map()) => state.set('bits', OrderedMap());
 
 const addBit = (state = Map(), bit) => state.setIn(['bits', bit.get('postId')], bit);
 

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -60,12 +60,15 @@ export const FILTER_TAG_EDGEGUARDING = Symbol.for('Edgeguarding');
 export const FILTER_TAG_COMBOS = Symbol.for('Combos');
 export const FILTER_TAG_ESCAPES = Symbol.for('Escapes');
 
+const DEFAULT_PAGE_SIZE = 25;
+
 const INITIAL_STATE = fromJS({
   bits: OrderedMap(),
   sorting: {
     sorts: [SORT_DATE, SORT_SCORE],
     currentSort: SORT_DATE
   },
+  pageSize: DEFAULT_PAGE_SIZE,
   filtering: {
     chars: [
         FILTER_CHAR_LUIGI,


### PR DESCRIPTION
Causes the client to actually go to the server when you change the sort order instead of just re-sorting the Bits it already knows about client-side.

One optimization: if there's less than 1 page of Bits displayed (currently hardcoded to 25), it'll short circuit the RPC and just do client-side sorting.