### PR TITLE
Add option to use client-local fake data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
     "react-scripts": "1.0.13",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
-    "urijs": "^1.19.1"
+    "urijs": "^1.19.1",
+    "uuid": "^3.3.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -12,7 +12,7 @@ const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
 const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: 'date', [SORT_SCORE]: 'score' };
 // Set this to true in development to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = true && process.env.NODE_ENV === 'development';
+const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
 
 export function fetchBits(sort, dispatch) {
   let fetchPromise;
@@ -35,7 +35,8 @@ export function fetchBit(bitId, dispatch) {
     fetchPromise = fakeClient.fetchBit(bitId);
   } else {
     fetchPromise = fetch(new URI(BASE_URI).segment([BITS_PATH, bitId]).toString())
-        .then(result => result.json(), error => console.log('Error fetching bit: ' + bitId, error));
+        .then(result => result.json())
+        .catch(error => console.log('Error fetching bit: ' + bitId, error));
   }
   fetchPromise
       .then(response => dispatch(addBit(jsonToBit(response.bit))));
@@ -47,7 +48,8 @@ export function fetchComments(bitId, dispatch) {
     fetchPromise = fakeClient.fetchComments(bitId);
   } else {
     fetchPromise = fetch(new URI(BASE_URI).segment([BITS_PATH, bitId, COMMENTS_PATH]).toString())
-        .then(result => result.json(), error => console.log('Error fetching comments', error));
+        .then(result => result.json())
+        .catch(error => console.log('Error fetching comments', error));
   }
   fetchPromise
       .then(response => dispatch(receiveComments(bitId, fromJS(response))));
@@ -58,17 +60,19 @@ export function createBit(bit, dispatch) {
   if (USE_FAKE_CLIENT) {
     fetchPromise = fakeClient.createBit(bit);
   } else {
-    fetchPromise = fetch(new URI(BASE_URI).path(BITS_PATH).toString(),
-      {
-        body: JSON.stringify({bit: bit}),
-        headers: {
-          'content-type': 'application/json',
-        },
-        method: 'POST',
-        mode: 'cors',
-        redirect: 'follow',
-      })
-        .then(result => result.headers.get('location'), error => console.log('Error creating bit', error));
+    fetchPromise =
+        fetch(new URI(BASE_URI).path(BITS_PATH).toString(),
+            {
+              body: JSON.stringify({bit: bit}),
+              headers: {
+                'content-type': 'application/json',
+              },
+              method: 'POST',
+              mode: 'cors',
+              redirect: 'follow',
+            })
+        .then(result => result.headers.get('location'))
+        .catch(error => console.log('Error creating bit', error));
   }
   fetchPromise
       .then(bitUrl => dispatch(receiveCreateBit(bitUrl)));

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -12,7 +12,7 @@ const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
 const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: 'date', [SORT_SCORE]: 'score' };
 // Set this to true in development to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = true;
+const USE_FAKE_CLIENT = false;
 
 export function fetchBits(sort, dispatch) {
   let fetchPromise;

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -12,7 +12,7 @@ const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
 const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: 'date', [SORT_SCORE]: 'score' };
 // Set this to true in development to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = false;
+const USE_FAKE_CLIENT = true && process.env.NODE_ENV === 'development';
 
 export function fetchBits(sort, dispatch) {
   let fetchPromise;
@@ -67,9 +67,9 @@ export function createBit(bit, dispatch) {
         method: 'POST',
         mode: 'cors',
         redirect: 'follow',
-      });
+      })
+        .then(result => result.headers.get('location'), error => console.log('Error creating bit', error));
   }
   fetchPromise
-      .then(result => result.headers.get('location'), error => console.log('Error creating bit', error))
       .then(bitUrl => dispatch(receiveCreateBit(bitUrl)));
 }

--- a/client/src/fake_api_client.js
+++ b/client/src/fake_api_client.js
@@ -1,0 +1,100 @@
+// A fake implementation of api_client with test data to avoid making an RPC during development.
+
+import uuid from 'uuid';
+
+const foxBit = {
+    postId: 'L3WDO8EL3LEKS',
+    author: {
+      personId: 'I2L3KFAE9GLREJ3',
+      name: 'Shears',
+    },
+    dateCreated: new Date(2017, 5, 1, 12, 12).getTime(),
+    upvotes: 10,
+    downvotes: 3,
+    title: 'Fox is unedgeguardable',
+    content: 'No matter what you do, you\'ll never be able to kill a recovering Fox.',
+    mainChars: ['Fox'],
+    standaloneTags: ['Edgeguarding'],
+};
+const handBit = {
+    postId: 'ME8DU23MNO0S',
+    author: {
+      personId: '562B3409SLL',
+      name: 'JonnJonn',
+    },
+    dateCreated: new Date(1993, 6, 24).getTime(),
+    upvotes: 42,
+    downvotes: 8,
+    title: 'Master Hand\'s getup attack',
+    content: 'It\'s a 1HKO.',
+    stages: ['Dream Land,Congo Jungle'],
+    standaloneTags: ['Approach'],
+};
+const falconPressureBit = {
+    postId: 'JNHQ98ASKJAK',
+    author: {
+      personId: '82JS0NG28XL1',
+      name: 'LowwwPower',
+    },
+    dateCreated: new Date(2010, 8, 12, 6, 17, 53).getTime(),
+    upvotes: 53,
+    downvotes: 21,
+    title: 'Falcon shield pressure against Yoshi',
+    content: 'A way to pressure Yoshis that love baiting platform push off by holding shield, especially when you are respawning and have invincibility. Even if you don\'t get the break, they often times get hit trying to escape which can lead to a bunch of combo starters.',
+    mainChars: ['Captain Falcon'],
+    vsChars: ['Yoshi'],
+};
+const bits =[foxBit, handBit, falconPressureBit];
+
+const foxComment1 = {
+  id: 'J78S348M293',
+  postId: 'L3WDO8EL3LEKS',
+  author: {
+    personId: 'JAS724IR8933',
+    name: 'LD'
+  },
+  dateCreated: new Date(2018, 1, 14, 10, 11, 16).getTime(),
+  content: 'Not true.'
+};
+const foxComment2 = {
+  id: 'B72902B3846',
+  postId: 'L3WDO8EL3LEKS',
+  author: {
+    personId: 'L187S60DD3',
+    name: 'n00bl33t'
+  },
+  dateCreated: new Date(2018, 1, 17, 6, 13, 28).getTime(),
+  content: 'Pshh what do you know'
+};
+const handComment = {
+  id: 'I26739X7034',
+  postId: 'ME8DU23MNO0S',
+  author: {
+    personId: 'R67218386X',
+    name: 'Cobr'
+  },
+  dateCreated: new Date(2000, 11, 10, 5, 11, 45).getTime(),
+  content: 'This is the kind of investigative reporting we need right now.'
+};
+const comments = [foxComment1, foxComment2, handComment];
+
+export function fetchBits() {
+  return Promise.resolve({ bits: bits });
+}
+
+export function fetchBit(bitId) {
+  return Promise.resolve({ bit: bits.filter(bit => bit.postId === bitId) });
+}
+
+export function fetchComments(bitId) {
+  return Promise.resolve(comments.filter(comment => comment.postId === bitId));
+}
+
+export function createBit(bit) {
+  bits.push({
+    ...bit,
+    postId: uuid.v1(),
+    dateCreated: new Date().getTime(),
+  });
+  // TODO: Return a 201 response
+}

--- a/client/src/fake_api_client.js
+++ b/client/src/fake_api_client.js
@@ -83,7 +83,7 @@ export function fetchBits() {
 }
 
 export function fetchBit(bitId) {
-  return Promise.resolve({ bit: bits.filter(bit => bit.postId === bitId) });
+  return Promise.resolve({ bit: bits.find(bit => bit.postId === bitId) });
 }
 
 export function fetchComments(bitId) {
@@ -96,5 +96,6 @@ export function createBit(bit) {
     postId: uuid.v1(),
     dateCreated: new Date().getTime(),
   });
+  return Promise.resolve('/bits' + bits.slice(-1)[0]);
   // TODO: Return a 201 response
 }

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -2,83 +2,6 @@ import uuid from 'uuid';
 import mongoose from 'mongoose';
 import Bit from './Bit';
 
-// TODO(thenuge): Replace this test data with real data from the DB.
-const foxBit = {
-    id: 'L3WDO8EL3LEKS',
-    author: {
-      person_id: 'I2L3KFAE9GLREJ3',
-      name: 'Shears',
-    },
-    date_created: new Date(2017, 5, 1, 12, 12).getTime(),
-    upvotes: 10,
-    downvotes: 3,
-    title: 'Fox is unedgeguardable',
-    content: 'No matter what you do, you\'ll never be able to kill a recovering Fox.',
-    mainChars: ['Fox'],
-    standaloneTags: ['Edgeguarding'],
-};
-const handBit = {
-    id: 'ME8DU23MNO0S',
-    author: {
-      person_id: '562B3409SLL',
-      name: 'JonnJonn',
-    },
-    date_created: new Date(1993, 6, 24).getTime(),
-    upvotes: 42,
-    downvotes: 8,
-    title: 'Master Hand\'s getup attack',
-    content: 'It\'s a 1HKO.',
-    stages: ['Dream Land', 'Congo Jungle'],
-    standaloneTags: ['Approach'],
-};
-const falconPressureBit = {
-    id: 'JNHQ98ASKJAK',
-    author: {
-      person_id: '82JS0NG28XL1',
-      name: 'LowwwPower',
-    },
-    date_created: new Date(2010, 8, 12, 6, 17, 53).getTime(),
-    upvotes: 53,
-    downvotes: 21,
-    title: 'Falcon shield pressure against Yoshi',
-    content: 'A way to pressure Yoshis that love baiting platform push off by holding shield, especially when you are respawning and have invincibility. Even if you don\'t get the break, they often times get hit trying to escape which can lead to a bunch of combo starters.',
-    mainChars: ['Captain Falcon'],
-    vsChars: ['Yoshi'],
-};
-const bits = {bits: [foxBit, handBit, falconPressureBit]};
-
-const foxComment1 = {
-  id: 'J78S348M293',
-  bit_id: 'L3WDO8EL3LEKS',
-  author: {
-    person_id: 'JAS724IR8933',
-    name: 'LD'
-  },
-  date_created: new Date(2018, 1, 14, 10, 11, 16).getTime(),
-  content: 'Not true.'
-};
-const foxComment2 = {
-  id: 'B72902B3846',
-  bit_id: 'L3WDO8EL3LEKS',
-  author: {
-    person_id: 'L187S60DD3',
-    name: 'n00bl33t'
-  },
-  date_created: new Date(2018, 1, 17, 6, 13, 28).getTime(),
-  content: 'Pshh what do you know'
-};
-const handComment = {
-  id: 'I26739X7034',
-  bit_id: 'ME8DU23MNO0S',
-  author: {
-    person_id: 'R67218386X',
-    name: 'Cobr'
-  },
-  date_created: new Date(2000, 11, 10, 5, 11, 45).getTime(),
-  content: 'This is the kind of investigative reporting we need right now.'
-};
-const comments = [foxComment1, foxComment2, handComment];
-
 const DEFAULT_PAGE_SIZE = 25;
 
 mongoose.Promise = global.Promise;
@@ -127,5 +50,5 @@ export function putBit(bit) {
 }
 
 export function queryComments(bitId) {
-  return comments.filter(comment => comment.bit_id === bitId);
+  /* Not implemented */
 }


### PR DESCRIPTION
Decided to just define an in-code flag, USE_FAKE_CLIENT, that you can change locally to avoid making an RPC in development... hopefully we don't accidentally turn on the flag and commit, but I'm too lazy to make it a proper build flag 😃 