### PR TITLE
Client routing for filters in query params

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "^3.3.7",
     "immutable": "^4.0.0-rc.9",
     "jquery": "^3.2.1",
+    "lodash": "^4.17.15",
     "react": "^16.3.1",
     "react-bootstrap": "^0.31.5",
     "react-dom": "^16.3.1",

--- a/client/src/BitsContainer.js
+++ b/client/src/BitsContainer.js
@@ -13,8 +13,8 @@ const BitsContainer = props => (
   </div>
 );
 
-const mapStateToProps = state => ({
-  bits: filterBits(state),
+const mapStateToProps = (state, ownProps) => ({
+  bits: filterBits(state, ownProps.filters),
   comments: state.get('comments', Map())
 });
 

--- a/client/src/FilterControl.js
+++ b/client/src/FilterControl.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import * as actionCreators from './action_creators';
-import { Map } from 'immutable';
+import { List, Map, fromJS } from 'immutable';
 import FilterMenu from './FilterMenu';
 import { Panel } from 'react-bootstrap';
 
@@ -14,32 +14,32 @@ const FilterControl = props => {
           title="These characters"
           bootstrapStyle="success"
           allFilters={filtering.get('chars')}
-          currentFilters={filtering.get('currentMainChars')}
+          currentFilters={filtering.get('currentMainChars', List())}
           onClick={toggleMainCharFilter} />
       <FilterMenu
           title="vs. these characters"
           bootstrapStyle="danger"
           allFilters={filtering.get('chars')}
-          currentFilters={filtering.get('currentVsChars')}
+          currentFilters={filtering.get('currentVsChars', List())}
           onClick={toggleVsCharFilter} />
       <FilterMenu
           title="on these stages"
           bootstrapStyle="primary"
           allFilters={filtering.get('stages')}
-          currentFilters={filtering.get('currentStages')}
+          currentFilters={filtering.get('currentStages', List())}
           onClick={toggleStageFilter} />
       <FilterMenu
           title="with these tags"
           bootstrapStyle="warning"
           allFilters={filtering.get('standaloneTags')}
-          currentFilters={filtering.get('currentStandaloneTags')}
+          currentFilters={filtering.get('currentStandaloneTags', List())}
           onClick={toggleStandaloneTagFilter} />
     </Panel>
   );
 };
 
-const mapStateToProps = state => ({
-  filtering: state.get('filtering')
+const mapStateToProps = (state, ownProps) => ({
+  filtering: state.get('filtering').merge(fromJS(ownProps.filters))
 });
 
 export default connect(mapStateToProps, actionCreators)(FilterControl);

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -7,7 +7,8 @@ import SortingMenu from './SortingMenu';
 import FilterControl from './FilterControl';
 import PageSizeMenu from './PageSizeMenu';
 import * as actionCreators from './action_creators';
-import { getFilters } from './uri_util';
+import { getFilters, getSort, getPageSize } from './uri_util';
+import { SORT_DATE, DEFAULT_PAGE_SIZE } from './reducer';
 
 class Home extends Component {
   constructor(props, context) {
@@ -26,14 +27,14 @@ class Home extends Component {
         </Col>
         <Col md={8}>
           <span>
-            <SortingMenu />
+            <SortingMenu sort={getSort(location.search) || SORT_DATE} />
             <span style={{float: 'right'}}>
-              <PageSizeMenu />
+              <PageSizeMenu pageSize={getPageSize(location.search) || DEFAULT_PAGE_SIZE} />
               <Button onClick={() => fetchPreviousPage()}> &lt; </Button>
               <Button onClick={() => fetchNextPage()}> &gt; </Button>
             </span>
           </span>
-          <BitsContainer filters={getFilters(location.search)}/>
+          <BitsContainer filters={getFilters(location.search)} />
         </Col>
       </div>
     );

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -7,6 +7,7 @@ import SortingMenu from './SortingMenu';
 import FilterControl from './FilterControl';
 import PageSizeMenu from './PageSizeMenu';
 import * as actionCreators from './action_creators';
+import { getFilters } from './uri_util';
 
 class Home extends Component {
   constructor(props, context) {
@@ -16,12 +17,12 @@ class Home extends Component {
   }
 
   render() {
-    const { fetchNextPage, fetchPreviousPage } = this.props;
+    const { fetchNextPage, fetchPreviousPage, location } = this.props;
     return (
       <div>
         <Col md={4}>
           <CreateBitButton />
-          <FilterControl />
+          <FilterControl filters={getFilters(location.search)} />
         </Col>
         <Col md={8}>
           <span>
@@ -32,7 +33,7 @@ class Home extends Component {
               <Button onClick={() => fetchNextPage()}> &gt; </Button>
             </span>
           </span>
-          <BitsContainer />
+          <BitsContainer filters={getFilters(location.search)}/>
         </Col>
       </div>
     );

--- a/client/src/PageSizeMenu.js
+++ b/client/src/PageSizeMenu.js
@@ -20,8 +20,8 @@ const PageSizeMenu = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  pageSize: state.get('pageSize'),
+const mapStateToProps = (state, ownProps) => ({
+  pageSize: ownProps.pageSize,
 });
 
 export default connect(mapStateToProps, actionCreators)(PageSizeMenu);

--- a/client/src/SortingMenu.js
+++ b/client/src/SortingMenu.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Map } from 'immutable';
 import * as actionCreators from './action_creators';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 const SortingMenu = props => {
-  const { sorts = Map(), currentSort, changeSort } = props;
+  const { sorts, currentSort, changeSort } = props;
   return (
     <DropdownButton bsStyle="info" title={`Sorting: ${currentSort}`} id="sorting-menu">
       {sorts.map(sort =>
@@ -16,9 +15,9 @@ const SortingMenu = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  sorts: state.getIn(['sorting', 'sorts']),
-  currentSort: state.getIn(['sorting', 'currentSort']),
+const mapStateToProps = (state, ownProps) => ({
+  sorts: state.get('sorts'),
+  currentSort: ownProps.sort,
 });
 
 export default connect(mapStateToProps, actionCreators)(SortingMenu);

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -9,13 +9,13 @@ import {
     ACTION_RECEIVE_COMMENTS,
     ACTION_REQUEST_CREATE_BIT,
     ACTION_RECEIVE_CREATE_BIT,
-    ACTION_SET_OFFSET,
-    ACTION_SET_PAGE_SIZE,
+    DEFAULT_PAGE_SIZE,
 } from './reducer';
 import { fetchBit as fetchBitApi, fetchBits as fetchBitsApi, fetchComments as fetchCommentsApi, createBit as createBitApi } from './api_client';
 import history from './history';
 import {
-  getFilters,
+  getOffset,
+  getPageSize,
   setMainCharsQuery,
   toggleMainCharQuery,
   setVsCharsQuery,
@@ -24,6 +24,9 @@ import {
   toggleStageQuery,
   setStandaloneTagsQuery,
   toggleStandaloneTagQuery,
+  setSortQuery,
+  setOffsetQuery,
+  setPageSizeQuery,
 } from './uri_util';
 
 export function clearBits() {
@@ -69,14 +72,16 @@ function refreshBits() {
 
 export function changeSort(sort) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_CHANGE_SORT,
-      data: sort
-    });
+    history.push(setSortQuery(sort, history.location.search));
 
     // If we have less than 1 page of bits, we can just sort them client-side.
     if (getState().get('bits').size >= getState().get('pageSize')) {
       dispatch(refreshBits());
+    } else {
+      dispatch({
+        type: ACTION_CHANGE_SORT,
+        data: sort
+      });
     }
   };
 }
@@ -159,25 +164,16 @@ export function fetchBit(bitId) {
   }
 }
 
-export function fetchBits({ sort, offset, limit, mainChars, vsChars, stages, standaloneTags } = {}) {
+export function fetchBits() {
   return function(dispatch, getState) {
-    const filters = getFilters(history.location.search);
-    return fetchBitsApi({
-      sort: sort || getState().getIn(['sorting', 'currentSort']),
-      offset: offset || getState().get('offset'),
-      pageSize: limit || getState().get('pageSize'),
-      mainChars: mainChars || filters.currentMainChars,
-      vsChars: vsChars || filters.currentVsChars,
-      stages: stages || filters.currentStages,
-      standaloneTags: standaloneTags || filters.currentStandaloneTags,
-      dispatch: dispatch
-    });
+    return fetchBitsApi(dispatch: dispatch);
   }
 }
 
 export function fetchNextPage() {
   return function(dispatch, getState) {
-    var offset = getState().get('offset') + getState().get('pageSize');
+    const offset = (getOffset(history.location.search) || 0)
+        + (getPageSize(history.location.search) || DEFAULT_PAGE_SIZE);
     dispatch(setOffset(offset));
     dispatch(refreshBits());
   };
@@ -185,26 +181,24 @@ export function fetchNextPage() {
 
 export function fetchPreviousPage() {
   return function(dispatch, getState) {
-    var offset = Math.max(0, getState().get('offset') - getState().get('pageSize'));
+    const offset = Math.max(
+        0,
+        (getOffset(history.location.search) || 0)
+          - (getPageSize(history.location.search) || DEFAULT_PAGE_SIZE));
     dispatch(setOffset(offset));
     dispatch(refreshBits());
   };
 }
 
 export function setOffset(offset) {
-  return {
-    type: ACTION_SET_OFFSET,
-    data: offset
+  return function(dispatch, getState) {
+    history.push(setOffsetQuery(offset, history.location.search));
   }
 }
 
 export function setPageSize(pageSize) {
   return function(dispatch) {
-    dispatch({
-      type: ACTION_SET_PAGE_SIZE,
-      data: pageSize
-    });
-    dispatch(setOffset(0));
+    history.push(setPageSizeQuery(pageSize, setOffsetQuery(0, history.location.search)));
     dispatch(refreshBits());
   }
 }

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -5,14 +5,6 @@ import {
     ACTION_DOWNVOTE,
     ACTION_RESET_VOTE,
     ACTION_CHANGE_SORT,
-    ACTION_TOGGLE_MAIN_CHAR_FILTER,
-    ACTION_TOGGLE_VS_CHAR_FILTER,
-    ACTION_TOGGLE_STAGE_FILTER,
-    ACTION_TOGGLE_STANDALONE_TAG_FILTER,
-    ACTION_SET_MAIN_CHAR_FILTERS,
-    ACTION_SET_VS_CHAR_FILTERS,
-    ACTION_SET_STAGE_FILTERS,
-    ACTION_SET_STANDALONE_TAG_FILTERS,
     ACTION_REQUEST_COMMENTS,
     ACTION_RECEIVE_COMMENTS,
     ACTION_REQUEST_CREATE_BIT,
@@ -21,6 +13,18 @@ import {
     ACTION_SET_PAGE_SIZE,
 } from './reducer';
 import { fetchBit as fetchBitApi, fetchBits as fetchBitsApi, fetchComments as fetchCommentsApi, createBit as createBitApi } from './api_client';
+import history from './history';
+import {
+  getFilters,
+  setMainCharsQuery,
+  toggleMainCharQuery,
+  setVsCharsQuery,
+  toggleVsCharQuery,
+  setStagesQuery,
+  toggleStageQuery,
+  setStandaloneTagsQuery,
+  toggleStandaloneTagQuery,
+} from './uri_util';
 
 export function clearBits() {
   return {
@@ -79,88 +83,56 @@ export function changeSort(sort) {
 
 export function setMainCharFilters(chars) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_SET_MAIN_CHAR_FILTERS,
-      data: chars
-    });
-
+    history.push(setMainCharsQuery(chars, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function toggleMainCharFilter(char) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_TOGGLE_MAIN_CHAR_FILTER,
-      data: char
-    });
-
+    history.push(toggleMainCharQuery(char, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function setVsCharFilters(chars) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_SET_VS_CHAR_FILTERS,
-      data: chars
-    });
-
+    history.push(setVsCharsQuery(chars, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function toggleVsCharFilter(char) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_TOGGLE_VS_CHAR_FILTER,
-      data: char
-    });
-
+    history.push(toggleVsCharQuery(char, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function setStageFilters(stages) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_SET_STAGE_FILTERS,
-      data: stages
-    });
-
+    history.push(setStagesQuery(stages, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function toggleStageFilter(stage) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_TOGGLE_STAGE_FILTER,
-      data: stage
-    });
-
+    history.push(toggleStageQuery(stage, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function setStandaloneTagFilters(tags) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_SET_STANDALONE_TAG_FILTERS,
-      data: tags
-    });
-
+    history.push(setStandaloneTagsQuery(tags, history.location.search));
     dispatch(refreshBits());
   };
 }
 
 export function toggleStandaloneTagFilter(tag) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_TOGGLE_STANDALONE_TAG_FILTER,
-      data: tag
-    });
-
+    history.push(toggleStandaloneTagQuery(tag, history.location.search));
     dispatch(refreshBits());
   };
 }
@@ -189,14 +161,15 @@ export function fetchBit(bitId) {
 
 export function fetchBits({ sort, offset, limit, mainChars, vsChars, stages, standaloneTags } = {}) {
   return function(dispatch, getState) {
+    const filters = getFilters(history.location.search);
     return fetchBitsApi({
       sort: sort || getState().getIn(['sorting', 'currentSort']),
       offset: offset || getState().get('offset'),
       pageSize: limit || getState().get('pageSize'),
-      mainChars: mainChars || getState().getIn(['filtering', 'currentMainChars']),
-      vsChars: vsChars || getState().getIn(['filtering', 'currentVsChars']),
-      stages: stages || getState().getIn(['filtering', 'currentStages']),
-      standaloneTags: standaloneTags || getState().getIn(['filtering', 'currentStandaloneTags']),
+      mainChars: mainChars || filters.currentMainChars,
+      vsChars: vsChars || filters.currentVsChars,
+      stages: stages || filters.currentStages,
+      standaloneTags: standaloneTags || filters.currentStandaloneTags,
       dispatch: dispatch
     });
   }

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -1,8 +1,6 @@
 import { addBit, receiveComments, receiveCreateBit } from './action_creators';
-import { SORT_DATE, SORT_SCORE } from './reducer';
 import * as fakeClient from './fake_api_client';
-import * as query from 'Shared/query_params';
-import { getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
+import history from './history';
 import { fromJS } from 'immutable';
 import URI from 'urijs';
 
@@ -11,11 +9,10 @@ const BASE_URI = process.env.NODE_ENV === 'production'
     : 'http://localhost:3001';
 const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
-const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: query.SORT_PARAM_DATE, [SORT_SCORE]: query.SORT_PARAM_DATE };
 // Set this to true in development to use local, fake data instead of making any RPCs.
 const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
 
-export function fetchBits({sort, offset, pageSize, mainChars, vsChars, stages, standaloneTags, dispatch}) {
+export function fetchBits(dispatch) {
   let fetchPromise;
   if (USE_FAKE_CLIENT) {
     fetchPromise = fakeClient.fetchBits();
@@ -23,16 +20,7 @@ export function fetchBits({sort, offset, pageSize, mainChars, vsChars, stages, s
     fetchPromise =
         fetch(new URI(BASE_URI)
             .path(BITS_PATH)
-            // TODO(thenuge): The query logic can be replaced with the URL querystring once we've migrated each param over.
-            .query({
-                ...sort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[sort] },
-                ...offset && { [query.QUERY_OFFSET]: offset },
-                ...pageSize && { [query.QUERY_LIMIT]: pageSize },
-                ...mainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(mainChars) },
-                ...vsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(vsChars) },
-                ...stages && { [query.QUERY_STAGES]: getStageFilterQuery(stages) },
-                ...standaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(standaloneTags) },
-              })
+            .query(history.location.search)
             .toString())
         .then(result => result.json())
         .catch(error => {

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -1,8 +1,8 @@
 import { addBit, receiveComments, receiveCreateBit } from './action_creators';
 import { SORT_DATE, SORT_SCORE } from './reducer';
 import * as fakeClient from './fake_api_client';
-import * as filters from 'Shared/filters';
 import * as query from 'Shared/query_params';
+import { getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
 import { fromJS } from 'immutable';
 import URI from 'urijs';
 
@@ -23,14 +23,15 @@ export function fetchBits({sort, offset, pageSize, mainChars, vsChars, stages, s
     fetchPromise =
         fetch(new URI(BASE_URI)
             .path(BITS_PATH)
+            // TODO(thenuge): The query logic can be replaced with the URL querystring once we've migrated each param over.
             .query({
                 ...sort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[sort] },
                 ...offset && { [query.QUERY_OFFSET]: offset },
                 ...pageSize && { [query.QUERY_LIMIT]: pageSize },
-                ...mainChars.size && { [query.QUERY_MAIN_CHARS]: mainChars.map(char => filters.DISPLAY_TO_PARAMS_CHARS[char]).join(',') },
-                ...vsChars.size && { [query.QUERY_VS_CHARS]: vsChars.map(char => filters.DISPLAY_TO_PARAMS_CHARS[char]).join(',') },
-                ...stages.size && { [query.QUERY_STAGES]: stages.map(stage => filters.DISPLAY_TO_PARAMS_STAGES[stage]).join(',') },
-                ...standaloneTags.size && { [query.QUERY_TAGS]: standaloneTags.map(tag => filters.DISPLAY_TO_PARAMS_TAGS[tag]).join(',') },
+                ...mainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(mainChars) },
+                ...vsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(vsChars) },
+                ...stages && { [query.QUERY_STAGES]: getStageFilterQuery(stages) },
+                ...standaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(standaloneTags) },
               })
             .toString())
         .then(result => result.json())

--- a/client/src/bits_util.js
+++ b/client/src/bits_util.js
@@ -1,11 +1,11 @@
 import { Map, Set } from 'immutable';
 
-export const filterBits = state => {
+export const filterBits = (state, filters = {}) => {
   const bits = state.get('bits', Map());
-  const mainChars = state.getIn(['filtering', 'currentMainChars'], Set());
-  const vsChars = state.getIn(['filtering', 'currentVsChars'], Set());
-  const stages = state.getIn(['filtering', 'currentStages'], Set());
-  const standaloneTags = state.getIn(['filtering', 'currentStandaloneTags'], Set());
+  const mainChars = Set(filters.currentMainChars || []);
+  const vsChars = Set(filters.currentVsChars || []);
+  const stages = Set(filters.currentStages || []);
+  const standaloneTags = Set(filters.currentStandaloneTags || []);
 
   return bits.filter(bit =>
       (mainChars.size === 0

--- a/client/src/fake_api_client.js
+++ b/client/src/fake_api_client.js
@@ -27,7 +27,7 @@ const handBit = {
     downvotes: 8,
     title: 'Master Hand\'s getup attack',
     content: 'It\'s a 1HKO.',
-    stages: ['Dream Land,Congo Jungle'],
+    stages: ['Dream Land', 'Congo Jungle'],
     standaloneTags: ['Approach'],
 };
 const falconPressureBit = {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -7,7 +7,7 @@ import registerServiceWorker from './registerServiceWorker';
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
 import reducer from './reducer';
-import { BrowserRouter as Router } from "react-router-dom";
+import { Router } from "react-router-dom";
 import history from "./history";
 // Hack to ensure jQuery is registered before bootstrap.
 // See https://stackoverflow.com/questions/34120250/error-using-bootstrap-jquery-packages-in-es6-with-browserify.

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -14,8 +14,6 @@ export const ACTION_REQUEST_COMMENTS = 'ACTION_REQUEST_COMMENTS';
 export const ACTION_RECEIVE_COMMENTS = 'ACTION_RECEIVE_COMMENTS';
 export const ACTION_REQUEST_CREATE_BIT = 'ACTION_REQUEST_CREATE_BIT';
 export const ACTION_RECEIVE_CREATE_BIT = 'ACTION_RECEIVE_CREATE_BIT';
-export const ACTION_SET_OFFSET = 'ACTION_SET_OFFSET';
-export const ACTION_SET_PAGE_SIZE = 'ACTION_SET_PAGE_SIZE';
 
 export const USER_UPVOTE = 1;
 export const USER_DOWNVOTE = -1;
@@ -24,16 +22,11 @@ export const USER_DEFAULT_VOTE = 0;
 export const SORT_DATE = 'Date';
 export const SORT_SCORE = 'Score';
 
-const DEFAULT_PAGE_SIZE = 25;
+export const DEFAULT_PAGE_SIZE = 25;
 
 const INITIAL_STATE = fromJS({
   bits: OrderedMap(),
-  sorting: {
-    sorts: [SORT_DATE, SORT_SCORE],
-    currentSort: SORT_DATE
-  },
-  pageSize: DEFAULT_PAGE_SIZE,
-  offset: 0,
+  sorts: [SORT_DATE, SORT_SCORE],
   filtering: {
     chars: [
         filters.FILTER_CHAR_LUIGI,
@@ -98,10 +91,6 @@ export default function(state = INITIAL_STATE, action) {
       return state;
     case ACTION_RECEIVE_CREATE_BIT:
       return state;
-    case ACTION_SET_OFFSET:
-      return state.set('offset', action.data);
-    case ACTION_SET_PAGE_SIZE:
-      return state.set('pageSize', action.data);
     default:
       return state;
   }
@@ -127,13 +116,11 @@ const changeSort = (state = Map(), sort) => {
     case SORT_SCORE:
       return state.set('bits',
           state.get('bits', Map()).sortBy(
-              bit => -1 * (bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0))))
-          .setIn(['sorting', 'currentSort'], sort);
+              bit => -1 * (bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0))));
     case SORT_DATE:
       return state.set('bits',
           state.get('bits', Map()).sortBy(
-              bit => -1 * bit.get('dateCreated', 0)))
-          .setIn(['sorting', 'currentSort'], sort);
+              bit => -1 * bit.get('dateCreated', 0)));
     default:
       return state;
   }

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -10,14 +10,6 @@ export const ACTION_DOWNVOTE = 'ACTION_DOWNVOTE';
 export const ACTION_RESET_VOTE = 'ACTION_RESET_VOTE';
 export const ACTION_ADD_BIT = 'ACTION_ADD_BIT';
 export const ACTION_CHANGE_SORT = 'ACTION_CHANGE_SORT';
-export const ACTION_TOGGLE_MAIN_CHAR_FILTER = 'ACTION_TOGGLE_MAIN_CHAR_FILTER';
-export const ACTION_TOGGLE_VS_CHAR_FILTER = 'ACTION_TOGGLE_VS_CHAR_FILTER';
-export const ACTION_TOGGLE_STAGE_FILTER = 'ACTION_TOGGLE_STAGE_FILTER';
-export const ACTION_TOGGLE_STANDALONE_TAG_FILTER = 'ACTION_TOGGLE_STANDALONE_TAG_FILTER';
-export const ACTION_SET_MAIN_CHAR_FILTERS = 'ACTION_SET_MAIN_CHAR_FILTERS';
-export const ACTION_SET_VS_CHAR_FILTERS = 'ACTION_SET_VS_CHAR_FILTERS';
-export const ACTION_SET_STAGE_FILTERS = 'ACTION_SET_STAGE_FILTERS';
-export const ACTION_SET_STANDALONE_TAG_FILTERS = 'ACTION_SET_STANDALONE_TAG_FILTERS';
 export const ACTION_REQUEST_COMMENTS = 'ACTION_REQUEST_COMMENTS';
 export const ACTION_RECEIVE_COMMENTS = 'ACTION_RECEIVE_COMMENTS';
 export const ACTION_REQUEST_CREATE_BIT = 'ACTION_REQUEST_CREATE_BIT';
@@ -57,8 +49,6 @@ const INITIAL_STATE = fromJS({
         filters.FILTER_CHAR_PIKA,
         filters.FILTER_CHAR_JIGGLY
     ],
-    currentMainChars: Set(),
-    currentVsChars: Set(),
     stages: [
         filters.FILTER_STAGE_PEACH,
         filters.FILTER_STAGE_CONGO,
@@ -73,14 +63,12 @@ const INITIAL_STATE = fromJS({
         filters.FILTER_STAGE_FINAL_DESTINATION,
         filters.FILTER_STAGE_BATTLEFIELD
     ],
-    currentStages: Set(),
     standaloneTags: [
         filters.FILTER_TAG_APPROACH,
         filters.FILTER_TAG_EDGEGUARDING,
         filters.FILTER_TAG_COMBOS,
         filters.FILTER_TAG_ESCAPES
     ],
-    currentStandaloneTags: Set()
   }
 })
 
@@ -102,22 +90,6 @@ export default function(state = INITIAL_STATE, action) {
       return resetVote(state, action.data);
     case ACTION_CHANGE_SORT:
       return changeSort(state, action.data);
-    case ACTION_TOGGLE_MAIN_CHAR_FILTER:
-      return toggleMainChar(state, action.data);
-    case ACTION_TOGGLE_VS_CHAR_FILTER:
-      return toggleVsChar(state, action.data);
-    case ACTION_TOGGLE_STAGE_FILTER:
-      return toggleStage(state, action.data);
-    case ACTION_TOGGLE_STANDALONE_TAG_FILTER:
-      return toggleStandaloneTag(state, action.data);
-    case ACTION_SET_MAIN_CHAR_FILTERS:
-      return state.setIn(['filtering', 'currentMainChars'], action.data);
-    case ACTION_SET_VS_CHAR_FILTERS:
-      return state.setIn(['filtering', 'currentVsChars'], action.data);
-    case ACTION_SET_STAGE_FILTERS:
-      return state.setIn(['filtering', 'currentStages'], action.data);
-    case ACTION_SET_STANDALONE_TAG_FILTERS:
-      return state.setIn(['filtering', 'currentStandaloneTags'], action.data);
     case ACTION_REQUEST_COMMENTS:
       return state.setIn(['bits', action.data, 'isRequestingComments'], true);
     case ACTION_RECEIVE_COMMENTS:
@@ -166,24 +138,6 @@ const changeSort = (state = Map(), sort) => {
       return state;
   }
 };
-
-const toggleMainChar = (state = Map(), char) =>
-    state.setIn(['filtering', 'currentMainChars'],
-        toggleSetElement(state.getIn(['filtering', 'currentMainChars']), char));
-
-const toggleVsChar = (state = Map(), char) =>
-    state.setIn(['filtering', 'currentVsChars'],
-        toggleSetElement(state.getIn(['filtering', 'currentVsChars']), char));
-
-const toggleStage = (state = Map(), stage) =>
-    state.setIn(['filtering', 'currentStages'],
-        toggleSetElement(state.getIn(['filtering', 'currentStages']), stage));
-
-const toggleStandaloneTag = (state = Map(), tag) =>
-    state.setIn(['filtering', 'currentStandaloneTags'],
-        toggleSetElement(state.getIn(['filtering', 'currentStandaloneTags']), tag));
-
-const toggleSetElement = (set, element) => set.includes(element) ? set.delete(element) : set.add(element);
 
 const receiveComments = (state = Map(), bitId, newComments) =>
     state

--- a/client/src/uri_util.js
+++ b/client/src/uri_util.js
@@ -1,11 +1,23 @@
+import { SORT_DATE, SORT_SCORE } from './reducer';
 import { getCharFilters, getStageFilters, getTagFilters, getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
 import * as query from 'Shared/query_params';
 import URI from 'urijs';
 import * as _ from 'lodash';
 
-export const getFilters = queryString => {
+export const PARAM_TO_CLIENT_SORT = { [query.SORT_PARAM_DATE]: SORT_DATE, [query.SORT_PARAM_SCORE]: SORT_SCORE };
+export const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: query.SORT_PARAM_DATE, [SORT_SCORE]: query.SORT_PARAM_SCORE };
+
+export const getFilters = queryString => _.pick(
+    getDisplayQueryParams(queryString),
+    ['currentMainChars', 'currentVsChars', 'currentStages', 'currentStandaloneTags']
+);
+
+const getDisplayQueryParams = queryString => {
   const queryMap = URI(queryString).query(true);
   return {
+    ...queryMap[query.QUERY_SORT] && { currentSort: getSort(queryString) },
+    ...queryMap[query.QUERY_LIMIT] && { currentPageSize: getPageSize(queryString) },
+    ...queryMap[query.QUERY_OFFSET] && { currentOffset: getOffset(queryString) },
     ...queryMap[query.QUERY_MAIN_CHARS] && { currentMainChars: getCharFilters(queryMap[query.QUERY_MAIN_CHARS]) },
     ...queryMap[query.QUERY_VS_CHARS] && { currentVsChars: getCharFilters(queryMap[query.QUERY_VS_CHARS]) },
     ...queryMap[query.QUERY_STAGES] && { currentStages: getStageFilters(queryMap[query.QUERY_STAGES]) },
@@ -13,61 +25,82 @@ export const getFilters = queryString => {
   };
 };
 
+export const getSort = queryString => {
+  return PARAM_TO_CLIENT_SORT[URI(queryString).query(true)[query.QUERY_SORT]];
+};
+
+export const getPageSize = queryString => {
+  return parseInt(URI(queryString).query(true)[query.QUERY_LIMIT], 10);
+};
+
+export const getOffset = queryString => {
+  return parseInt(URI(queryString).query(true)[query.QUERY_OFFSET], 10);
+};
+
+export const setSortQuery = (sort, queryString) => {
+  return setQueryParam('currentSort', sort, queryString);
+}
+
+export const setPageSizeQuery = (pageSize, queryString) => {
+  return setQueryParam('currentPageSize', pageSize, queryString);
+}
+
+export const setOffsetQuery = (offset, queryString) => {
+  return setQueryParam('currentOffset', offset, queryString);
+}
+
 export const setMainCharsQuery = (chars, queryString) => {
-  const filters = { ...getFilters(queryString), currentMainChars: chars };
-  const uri = URI().search(displayFiltersToQuery(filters));
-  return uri.search();
+  return setQueryParam('currentMainChars', chars, queryString);
 }
 
 export const toggleMainCharQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentMainChars, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentMainChars: toggledFilters }));
-  return uri.search();
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentMainChars, [char]);
+  return setMainCharsQuery(toggledFilters, queryString);
 }
 
 export const setVsCharsQuery = (chars, queryString) => {
-  const filters = { ...getFilters(queryString), currentVsChars: chars };
-  const uri = URI().search(displayFiltersToQuery(filters));
-  return uri.search();
+  return setQueryParam('currentVsChars', chars, queryString);
 }
 
 export const toggleVsCharQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentVsChars, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentVsChars: toggledFilters }));
-  return uri.search();
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentVsChars, [char]);
+  return setVsCharsQuery(toggledFilters, queryString);
 }
 
 export const setStagesQuery = (stages, queryString) => {
-  const filters = { ...getFilters(queryString), currentStages: stages };
-  const uri = URI().search(displayFiltersToQuery(filters));
-  return uri.search();
+  return setQueryParam('currentStages', stages, queryString);
 }
 
 export const toggleStageQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentStages, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStages: toggledFilters }));
-  return uri.search();
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentStages, [char]);
+  return setStagesQuery(toggledFilters, queryString);
 }
 
 export const setStandaloneTagsQuery = (tags, queryString) => {
-  const filters = { ...getFilters(queryString), currentStandaloneTags: tags };
-  const uri = URI().search(displayFiltersToQuery(filters));
-  return uri.search();
+  return setQueryParam('currentStandaloneTags', tags, queryString);
 }
 
 export const toggleStandaloneTagQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentStandaloneTags, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStandaloneTags: toggledFilters }));
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentStandaloneTags, [char]);
+  return setStandaloneTagsQuery(toggledFilters, queryString);
+}
+
+const setQueryParam = (key, value, queryString) => {
+  const params = { ...getDisplayQueryParams(queryString), [key]: value };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 
-const displayFiltersToQuery = filters => _.pickBy({
-  ...filters.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(filters.currentMainChars) },
-  ...filters.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(filters.currentVsChars) },
-  ...filters.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(filters.currentStages) },
-  ...filters.currentStandaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(filters.currentStandaloneTags) },
+const displayParamsToQuery = params => _.pickBy({
+  ...params.currentSort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[params.currentSort] },
+  ...params.currentPageSize && { [query.QUERY_LIMIT]: params.currentPageSize },
+  ...params.currentOffset && { [query.QUERY_OFFSET]: params.currentOffset },
+  ...params.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(params.currentMainChars) },
+  ...params.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(params.currentVsChars) },
+  ...params.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(params.currentStages) },
+  ...params.currentStandaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(params.currentStandaloneTags) },
 }, _.identity);

--- a/client/src/uri_util.js
+++ b/client/src/uri_util.js
@@ -1,0 +1,73 @@
+import { getCharFilters, getStageFilters, getTagFilters, getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
+import * as query from 'Shared/query_params';
+import URI from 'urijs';
+import * as _ from 'lodash';
+
+export const getFilters = queryString => {
+  const queryMap = URI(queryString).query(true);
+  return {
+    ...queryMap[query.QUERY_MAIN_CHARS] && { currentMainChars: getCharFilters(queryMap[query.QUERY_MAIN_CHARS]) },
+    ...queryMap[query.QUERY_VS_CHARS] && { currentVsChars: getCharFilters(queryMap[query.QUERY_VS_CHARS]) },
+    ...queryMap[query.QUERY_STAGES] && { currentStages: getStageFilters(queryMap[query.QUERY_STAGES]) },
+    ...queryMap[query.QUERY_TAGS] && { currentStandaloneTags: getTagFilters(queryMap[query.QUERY_TAGS]) },
+  };
+};
+
+export const setMainCharsQuery = (chars, queryString) => {
+  const filters = { ...getFilters(queryString), currentMainChars: chars };
+  const uri = URI().search(displayFiltersToQuery(filters));
+  return uri.search();
+}
+
+export const toggleMainCharQuery = (char, queryString) => {
+  const filters = getFilters(queryString);
+  const toggledFilters = _.xor(filters.currentMainChars, [char]);
+  const uri = URI().search(displayFiltersToQuery({ ...filters, currentMainChars: toggledFilters }));
+  return uri.search();
+}
+
+export const setVsCharsQuery = (chars, queryString) => {
+  const filters = { ...getFilters(queryString), currentVsChars: chars };
+  const uri = URI().search(displayFiltersToQuery(filters));
+  return uri.search();
+}
+
+export const toggleVsCharQuery = (char, queryString) => {
+  const filters = getFilters(queryString);
+  const toggledFilters = _.xor(filters.currentVsChars, [char]);
+  const uri = URI().search(displayFiltersToQuery({ ...filters, currentVsChars: toggledFilters }));
+  return uri.search();
+}
+
+export const setStagesQuery = (stages, queryString) => {
+  const filters = { ...getFilters(queryString), currentStages: stages };
+  const uri = URI().search(displayFiltersToQuery(filters));
+  return uri.search();
+}
+
+export const toggleStageQuery = (char, queryString) => {
+  const filters = getFilters(queryString);
+  const toggledFilters = _.xor(filters.currentStages, [char]);
+  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStages: toggledFilters }));
+  return uri.search();
+}
+
+export const setStandaloneTagsQuery = (tags, queryString) => {
+  const filters = { ...getFilters(queryString), currentStandaloneTags: tags };
+  const uri = URI().search(displayFiltersToQuery(filters));
+  return uri.search();
+}
+
+export const toggleStandaloneTagQuery = (char, queryString) => {
+  const filters = getFilters(queryString);
+  const toggledFilters = _.xor(filters.currentStandaloneTags, [char]);
+  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStandaloneTags: toggledFilters }));
+  return uri.search();
+}
+
+const displayFiltersToQuery = filters => _.pickBy({
+  ...filters.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(filters.currentMainChars) },
+  ...filters.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(filters.currentVsChars) },
+  ...filters.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(filters.currentStages) },
+  ...filters.currentStandaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(filters.currentStandaloneTags) },
+}, _.identity);

--- a/server/src/bits.js
+++ b/server/src/bits.js
@@ -1,7 +1,7 @@
 import jsStringEscape from 'js-string-escape';
 import { queryBit, queryBits, putBit, queryComments } from './store';
-import * as filters from 'Shared/filters';
 import * as query from 'Shared/query_params';
+import { getCharFilters, getStageFilters, getTagFilters } from 'Shared/query_util';
 
 const SORTS = [query.SORT_PARAM_DATE, query.SORT_PARAM_SCORE];
 
@@ -12,10 +12,10 @@ export function getBit(req) {
 export function getBits(req) {
   const limit = parseInt(jsStringEscape(req.query[query.QUERY_LIMIT]));
   const offset = parseInt(jsStringEscape(req.query[query.QUERY_OFFSET]));
-  const mainChars = paramToFilterList(jsStringEscape(req.query[query.QUERY_MAIN_CHARS]), filters.PARAMS_TO_DISPLAY_CHARS);
-  const vsChars = paramToFilterList(jsStringEscape(req.query[query.QUERY_VS_CHARS]), filters.PARAMS_TO_DISPLAY_CHARS);
-  const stages = paramToFilterList(jsStringEscape(req.query[query.QUERY_STAGES]), filters.PARAMS_TO_DISPLAY_STAGES);
-  const standaloneTags = paramToFilterList(jsStringEscape(req.query[query.QUERY_TAGS]), filters.PARAMS_TO_DISPLAY_TAGS);
+  const mainChars = getCharFilters(jsStringEscape(req.query[query.QUERY_MAIN_CHARS]));
+  const vsChars = getCharFilters(jsStringEscape(req.query[query.QUERY_VS_CHARS]));
+  const stages = getStageFilters(jsStringEscape(req.query[query.QUERY_STAGES]));
+  const standaloneTags = getTagFilters(jsStringEscape(req.query[query.QUERY_TAGS]));
   return queryBits({
       sort: paramToSort(req.query[query.QUERY_SORT]),
       ...limit && { limit: limit },
@@ -52,6 +52,3 @@ const paramToSort = param => {
   const normalized = normalize(jsStringEscape(param));
   return SORTS.includes(normalized) ? normalized : query.SORT_PARAM_DATE;
 };
-
-const paramToFilterList = (jsonString, filterMap) =>
-  jsonString.split(',').map(param => filterMap[param]).filter(Boolean);

--- a/shared/src/query_util.js
+++ b/shared/src/query_util.js
@@ -1,0 +1,13 @@
+import * as filters from './filters';
+import * as query from './query_params';
+
+export const getCharFilters = queryString => paramToFilterList(queryString, filters.PARAMS_TO_DISPLAY_CHARS);
+export const getStageFilters = queryString => paramToFilterList(queryString, filters.PARAMS_TO_DISPLAY_STAGES);
+export const getTagFilters = queryString => paramToFilterList(queryString, filters.PARAMS_TO_DISPLAY_TAGS);
+
+export const getCharFilterQuery = chars => chars.map(char => filters.DISPLAY_TO_PARAMS_CHARS[char]).join(',');
+export const getStageFilterQuery = stages => stages.map(stage => filters.DISPLAY_TO_PARAMS_STAGES[stage]).join(',');
+export const getTagFilterQuery = tags => tags.map(tag => filters.DISPLAY_TO_PARAMS_TAGS[tag]).join(',');
+
+const paramToFilterList = (queryString, filterMap) =>
+  [...new Set(queryString.split(',').map(param => filterMap[param]).filter(Boolean))];


### PR DESCRIPTION
The user-visible change is that changing filters on the client now changes the query params, and the backstack works accordingly.

To do this, I've basically outsourced the job of maintaining the current filters to the URL bar and taken it away from the Redux store. Whenever we route to the homepage, it reads the query string, converts it to filters, and propagates those filters throughout the app. Whenever we change the filters, it pushes a new query string to the navigation stack.