### PR TITLE
Routing for the rest of the query params

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -7,8 +7,8 @@ import SortingMenu from './SortingMenu';
 import FilterControl from './FilterControl';
 import PageSizeMenu from './PageSizeMenu';
 import * as actionCreators from './action_creators';
-import { getFilters, getSort } from './uri_util';
-import { SORT_DATE } from './reducer';
+import { getFilters, getSort, getPageSize } from './uri_util';
+import { SORT_DATE, DEFAULT_PAGE_SIZE } from './reducer';
 
 class Home extends Component {
   constructor(props, context) {
@@ -29,7 +29,7 @@ class Home extends Component {
           <span>
             <SortingMenu sort={getSort(location.search) || SORT_DATE} />
             <span style={{float: 'right'}}>
-              <PageSizeMenu />
+              <PageSizeMenu pageSize={getPageSize(location.search) || DEFAULT_PAGE_SIZE} />
               <Button onClick={() => fetchPreviousPage()}> &lt; </Button>
               <Button onClick={() => fetchNextPage()}> &gt; </Button>
             </span>

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -7,7 +7,8 @@ import SortingMenu from './SortingMenu';
 import FilterControl from './FilterControl';
 import PageSizeMenu from './PageSizeMenu';
 import * as actionCreators from './action_creators';
-import { getFilters } from './uri_util';
+import { getFilters, getSort } from './uri_util';
+import { SORT_DATE } from './reducer';
 
 class Home extends Component {
   constructor(props, context) {
@@ -26,14 +27,14 @@ class Home extends Component {
         </Col>
         <Col md={8}>
           <span>
-            <SortingMenu />
+            <SortingMenu sort={getSort(location.search) || SORT_DATE} />
             <span style={{float: 'right'}}>
               <PageSizeMenu />
               <Button onClick={() => fetchPreviousPage()}> &lt; </Button>
               <Button onClick={() => fetchNextPage()}> &gt; </Button>
             </span>
           </span>
-          <BitsContainer filters={getFilters(location.search)}/>
+          <BitsContainer filters={getFilters(location.search)} />
         </Col>
       </div>
     );

--- a/client/src/PageSizeMenu.js
+++ b/client/src/PageSizeMenu.js
@@ -20,8 +20,8 @@ const PageSizeMenu = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  pageSize: state.get('pageSize'),
+const mapStateToProps = (state, ownProps) => ({
+  pageSize: ownProps.pageSize,
 });
 
 export default connect(mapStateToProps, actionCreators)(PageSizeMenu);

--- a/client/src/SortingMenu.js
+++ b/client/src/SortingMenu.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Map } from 'immutable';
 import * as actionCreators from './action_creators';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 const SortingMenu = props => {
-  const { sorts = Map(), currentSort, changeSort } = props;
+  const { sorts, currentSort, changeSort } = props;
   return (
     <DropdownButton bsStyle="info" title={`Sorting: ${currentSort}`} id="sorting-menu">
       {sorts.map(sort =>
@@ -16,9 +15,9 @@ const SortingMenu = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  sorts: state.getIn(['sorting', 'sorts']),
-  currentSort: state.getIn(['sorting', 'currentSort']),
+const mapStateToProps = (state, ownProps) => ({
+  sorts: state.get('sorts'),
+  currentSort: ownProps.sort,
 });
 
 export default connect(mapStateToProps, actionCreators)(SortingMenu);

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -14,7 +14,6 @@ import {
 import { fetchBit as fetchBitApi, fetchBits as fetchBitsApi, fetchComments as fetchCommentsApi, createBit as createBitApi } from './api_client';
 import history from './history';
 import {
-  getDisplayQueryParams,
   getOffset,
   getPageSize,
   setMainCharsQuery,
@@ -165,19 +164,9 @@ export function fetchBit(bitId) {
   }
 }
 
-export function fetchBits({ sort, offset, limit, mainChars, vsChars, stages, standaloneTags } = {}) {
+export function fetchBits() {
   return function(dispatch, getState) {
-    const params = getDisplayQueryParams(history.location.search);
-    return fetchBitsApi({
-      sort: sort || params.currentSort,
-      offset: offset || params.currentOffset,
-      pageSize: limit || params.currentPageSize,
-      mainChars: mainChars || params.currentMainChars,
-      vsChars: vsChars || params.currentVsChars,
-      stages: stages || params.currentStages,
-      standaloneTags: standaloneTags || params.currentStandaloneTags,
-      dispatch: dispatch
-    });
+    return fetchBitsApi(dispatch: dispatch);
   }
 }
 

--- a/client/src/action_creators.js
+++ b/client/src/action_creators.js
@@ -15,7 +15,7 @@ import {
 import { fetchBit as fetchBitApi, fetchBits as fetchBitsApi, fetchComments as fetchCommentsApi, createBit as createBitApi } from './api_client';
 import history from './history';
 import {
-  getFilters,
+  getDisplayQueryParams,
   setMainCharsQuery,
   toggleMainCharQuery,
   setVsCharsQuery,
@@ -24,6 +24,7 @@ import {
   toggleStageQuery,
   setStandaloneTagsQuery,
   toggleStandaloneTagQuery,
+  setSortQuery,
 } from './uri_util';
 
 export function clearBits() {
@@ -69,14 +70,16 @@ function refreshBits() {
 
 export function changeSort(sort) {
   return function(dispatch, getState) {
-    dispatch({
-      type: ACTION_CHANGE_SORT,
-      data: sort
-    });
+    history.push(setSortQuery(sort, history.location.search));
 
     // If we have less than 1 page of bits, we can just sort them client-side.
     if (getState().get('bits').size >= getState().get('pageSize')) {
       dispatch(refreshBits());
+    } else {
+      dispatch({
+        type: ACTION_CHANGE_SORT,
+        data: sort
+      });
     }
   };
 }
@@ -161,15 +164,15 @@ export function fetchBit(bitId) {
 
 export function fetchBits({ sort, offset, limit, mainChars, vsChars, stages, standaloneTags } = {}) {
   return function(dispatch, getState) {
-    const filters = getFilters(history.location.search);
+    const params = getDisplayQueryParams(history.location.search);
     return fetchBitsApi({
-      sort: sort || getState().getIn(['sorting', 'currentSort']),
+      sort: sort || params.currentSort,
       offset: offset || getState().get('offset'),
       pageSize: limit || getState().get('pageSize'),
-      mainChars: mainChars || filters.currentMainChars,
-      vsChars: vsChars || filters.currentVsChars,
-      stages: stages || filters.currentStages,
-      standaloneTags: standaloneTags || filters.currentStandaloneTags,
+      mainChars: mainChars || params.currentMainChars,
+      vsChars: vsChars || params.currentVsChars,
+      stages: stages || params.currentStages,
+      standaloneTags: standaloneTags || params.currentStandaloneTags,
       dispatch: dispatch
     });
   }

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -1,8 +1,6 @@
 import { addBit, receiveComments, receiveCreateBit } from './action_creators';
 import * as fakeClient from './fake_api_client';
-import { CLIENT_SORT_TO_PARAM } from './uri_util';
-import * as query from 'Shared/query_params';
-import { getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
+import history from './history';
 import { fromJS } from 'immutable';
 import URI from 'urijs';
 
@@ -14,7 +12,7 @@ const COMMENTS_PATH = '/comments';
 // Set this to true in development to use local, fake data instead of making any RPCs.
 const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
 
-export function fetchBits({sort, offset, pageSize, mainChars, vsChars, stages, standaloneTags, dispatch}) {
+export function fetchBits(dispatch) {
   let fetchPromise;
   if (USE_FAKE_CLIENT) {
     fetchPromise = fakeClient.fetchBits();
@@ -22,16 +20,7 @@ export function fetchBits({sort, offset, pageSize, mainChars, vsChars, stages, s
     fetchPromise =
         fetch(new URI(BASE_URI)
             .path(BITS_PATH)
-            // TODO(thenuge): The query logic can be replaced with the URL querystring once we've migrated each param over.
-            .query({
-                ...sort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[sort] },
-                ...offset && { [query.QUERY_OFFSET]: offset },
-                ...pageSize && { [query.QUERY_LIMIT]: pageSize },
-                ...mainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(mainChars) },
-                ...vsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(vsChars) },
-                ...stages && { [query.QUERY_STAGES]: getStageFilterQuery(stages) },
-                ...standaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(standaloneTags) },
-              })
+            .query(history.location.search)
             .toString())
         .then(result => result.json())
         .catch(error => {

--- a/client/src/api_client.js
+++ b/client/src/api_client.js
@@ -1,6 +1,6 @@
 import { addBit, receiveComments, receiveCreateBit } from './action_creators';
-import { SORT_DATE, SORT_SCORE } from './reducer';
 import * as fakeClient from './fake_api_client';
+import { CLIENT_SORT_TO_PARAM } from './uri_util';
 import * as query from 'Shared/query_params';
 import { getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
 import { fromJS } from 'immutable';
@@ -11,7 +11,6 @@ const BASE_URI = process.env.NODE_ENV === 'production'
     : 'http://localhost:3001';
 const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
-const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: query.SORT_PARAM_DATE, [SORT_SCORE]: query.SORT_PARAM_DATE };
 // Set this to true in development to use local, fake data instead of making any RPCs.
 const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
 

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -28,10 +28,7 @@ const DEFAULT_PAGE_SIZE = 25;
 
 const INITIAL_STATE = fromJS({
   bits: OrderedMap(),
-  sorting: {
-    sorts: [SORT_DATE, SORT_SCORE],
-    currentSort: SORT_DATE
-  },
+  sorts: [SORT_DATE, SORT_SCORE],
   pageSize: DEFAULT_PAGE_SIZE,
   offset: 0,
   filtering: {
@@ -127,13 +124,11 @@ const changeSort = (state = Map(), sort) => {
     case SORT_SCORE:
       return state.set('bits',
           state.get('bits', Map()).sortBy(
-              bit => -1 * (bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0))))
-          .setIn(['sorting', 'currentSort'], sort);
+              bit => -1 * (bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0))));
     case SORT_DATE:
       return state.set('bits',
           state.get('bits', Map()).sortBy(
-              bit => -1 * bit.get('dateCreated', 0)))
-          .setIn(['sorting', 'currentSort'], sort);
+              bit => -1 * bit.get('dateCreated', 0)));
     default:
       return state;
   }

--- a/client/src/reducer.js
+++ b/client/src/reducer.js
@@ -14,8 +14,6 @@ export const ACTION_REQUEST_COMMENTS = 'ACTION_REQUEST_COMMENTS';
 export const ACTION_RECEIVE_COMMENTS = 'ACTION_RECEIVE_COMMENTS';
 export const ACTION_REQUEST_CREATE_BIT = 'ACTION_REQUEST_CREATE_BIT';
 export const ACTION_RECEIVE_CREATE_BIT = 'ACTION_RECEIVE_CREATE_BIT';
-export const ACTION_SET_OFFSET = 'ACTION_SET_OFFSET';
-export const ACTION_SET_PAGE_SIZE = 'ACTION_SET_PAGE_SIZE';
 
 export const USER_UPVOTE = 1;
 export const USER_DOWNVOTE = -1;
@@ -24,13 +22,11 @@ export const USER_DEFAULT_VOTE = 0;
 export const SORT_DATE = 'Date';
 export const SORT_SCORE = 'Score';
 
-const DEFAULT_PAGE_SIZE = 25;
+export const DEFAULT_PAGE_SIZE = 25;
 
 const INITIAL_STATE = fromJS({
   bits: OrderedMap(),
   sorts: [SORT_DATE, SORT_SCORE],
-  pageSize: DEFAULT_PAGE_SIZE,
-  offset: 0,
   filtering: {
     chars: [
         filters.FILTER_CHAR_LUIGI,
@@ -95,10 +91,6 @@ export default function(state = INITIAL_STATE, action) {
       return state;
     case ACTION_RECEIVE_CREATE_BIT:
       return state;
-    case ACTION_SET_OFFSET:
-      return state.set('offset', action.data);
-    case ACTION_SET_PAGE_SIZE:
-      return state.set('pageSize', action.data);
     default:
       return state;
   }

--- a/client/src/uri_util.js
+++ b/client/src/uri_util.js
@@ -12,7 +12,7 @@ export const getFilters = queryString => _.pick(
     ['currentMainChars', 'currentVsChars', 'currentStages', 'currentStandaloneTags']
 );
 
-export const getDisplayQueryParams = queryString => {
+const getDisplayQueryParams = queryString => {
   const queryMap = URI(queryString).query(true);
   return {
     ...queryMap[query.QUERY_SORT] && { currentSort: getSort(queryString) },
@@ -38,72 +38,60 @@ export const getOffset = queryString => {
 };
 
 export const setSortQuery = (sort, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentSort: sort };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentSort', sort, queryString);
 }
 
 export const setPageSizeQuery = (pageSize, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentPageSize: pageSize };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentPageSize', pageSize, queryString);
 }
 
 export const setOffsetQuery = (offset, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentOffset: offset };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentOffset', offset, queryString);
 }
 
 export const setMainCharsQuery = (chars, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentMainChars: chars };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentMainChars', chars, queryString);
 }
 
 export const toggleMainCharQuery = (char, queryString) => {
   const params = getDisplayQueryParams(queryString);
   const toggledFilters = _.xor(params.currentMainChars, [char]);
-  const uri = URI().search(displayParamsToQuery({ ...params, currentMainChars: toggledFilters }));
-  return uri.search();
+  return setMainCharsQuery(toggledFilters, queryString);
 }
 
 export const setVsCharsQuery = (chars, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentVsChars: chars };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentVsChars', chars, queryString);
 }
 
 export const toggleVsCharQuery = (char, queryString) => {
   const params = getDisplayQueryParams(queryString);
   const toggledFilters = _.xor(params.currentVsChars, [char]);
-  const uri = URI().search(displayParamsToQuery({ ...params, currentVsChars: toggledFilters }));
-  return uri.search();
+  return setVsCharsQuery(toggledFilters, queryString);
 }
 
 export const setStagesQuery = (stages, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentStages: stages };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentStages', stages, queryString);
 }
 
 export const toggleStageQuery = (char, queryString) => {
   const params = getDisplayQueryParams(queryString);
   const toggledFilters = _.xor(params.currentStages, [char]);
-  const uri = URI().search(displayParamsToQuery({ ...params, currentStages: toggledFilters }));
-  return uri.search();
+  return setStagesQuery(toggledFilters, queryString);
 }
 
 export const setStandaloneTagsQuery = (tags, queryString) => {
-  const params = { ...getDisplayQueryParams(queryString), currentStandaloneTags: tags };
-  const uri = URI().search(displayParamsToQuery(params));
-  return uri.search();
+  return setQueryParam('currentStandaloneTags', tags, queryString);
 }
 
 export const toggleStandaloneTagQuery = (char, queryString) => {
   const params = getDisplayQueryParams(queryString);
   const toggledFilters = _.xor(params.currentStandaloneTags, [char]);
-  const uri = URI().search(displayParamsToQuery({ ...params, currentStandaloneTags: toggledFilters }));
+  return setStandaloneTagsQuery(toggledFilters, queryString);
+}
+
+const setQueryParam = (key, value, queryString) => {
+  const params = { ...getDisplayQueryParams(queryString), [key]: value };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 

--- a/client/src/uri_util.js
+++ b/client/src/uri_util.js
@@ -1,11 +1,21 @@
+import { SORT_DATE, SORT_SCORE } from './reducer';
 import { getCharFilters, getStageFilters, getTagFilters, getCharFilterQuery, getStageFilterQuery, getTagFilterQuery } from 'Shared/query_util';
 import * as query from 'Shared/query_params';
 import URI from 'urijs';
 import * as _ from 'lodash';
 
-export const getFilters = queryString => {
+export const PARAM_TO_CLIENT_SORT = { [query.SORT_PARAM_DATE]: SORT_DATE, [query.SORT_PARAM_SCORE]: SORT_SCORE };
+export const CLIENT_SORT_TO_PARAM = { [SORT_DATE]: query.SORT_PARAM_DATE, [SORT_SCORE]: query.SORT_PARAM_SCORE };
+
+export const getFilters = queryString => _.pick(
+    getDisplayQueryParams(queryString),
+    ['currentMainChars', 'currentVsChars', 'currentStages', 'currentStandaloneTags']
+);
+
+export const getDisplayQueryParams = queryString => {
   const queryMap = URI(queryString).query(true);
   return {
+    ...queryMap[query.QUERY_SORT] && { currentSort: getSort(queryString) },
     ...queryMap[query.QUERY_MAIN_CHARS] && { currentMainChars: getCharFilters(queryMap[query.QUERY_MAIN_CHARS]) },
     ...queryMap[query.QUERY_VS_CHARS] && { currentVsChars: getCharFilters(queryMap[query.QUERY_VS_CHARS]) },
     ...queryMap[query.QUERY_STAGES] && { currentStages: getStageFilters(queryMap[query.QUERY_STAGES]) },
@@ -13,61 +23,72 @@ export const getFilters = queryString => {
   };
 };
 
+export const getSort = queryString => {
+  return PARAM_TO_CLIENT_SORT[URI(queryString).query(true)[query.QUERY_SORT]];
+};
+
+export const setSortQuery = (sort, queryString) => {
+  const params = { ...getDisplayQueryParams(queryString), currentSort: sort };
+  const uri = URI().search(displayParamsToQuery(params));
+  return uri.search();
+}
+
 export const setMainCharsQuery = (chars, queryString) => {
-  const filters = { ...getFilters(queryString), currentMainChars: chars };
-  const uri = URI().search(displayFiltersToQuery(filters));
+  const params = { ...getDisplayQueryParams(queryString), currentMainChars: chars };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 
 export const toggleMainCharQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentMainChars, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentMainChars: toggledFilters }));
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentMainChars, [char]);
+  const uri = URI().search(displayParamsToQuery({ ...params, currentMainChars: toggledFilters }));
   return uri.search();
 }
 
 export const setVsCharsQuery = (chars, queryString) => {
-  const filters = { ...getFilters(queryString), currentVsChars: chars };
-  const uri = URI().search(displayFiltersToQuery(filters));
+  const params = { ...getDisplayQueryParams(queryString), currentVsChars: chars };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 
 export const toggleVsCharQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentVsChars, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentVsChars: toggledFilters }));
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentVsChars, [char]);
+  const uri = URI().search(displayParamsToQuery({ ...params, currentVsChars: toggledFilters }));
   return uri.search();
 }
 
 export const setStagesQuery = (stages, queryString) => {
-  const filters = { ...getFilters(queryString), currentStages: stages };
-  const uri = URI().search(displayFiltersToQuery(filters));
+  const params = { ...getDisplayQueryParams(queryString), currentStages: stages };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 
 export const toggleStageQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentStages, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStages: toggledFilters }));
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentStages, [char]);
+  const uri = URI().search(displayParamsToQuery({ ...params, currentStages: toggledFilters }));
   return uri.search();
 }
 
 export const setStandaloneTagsQuery = (tags, queryString) => {
-  const filters = { ...getFilters(queryString), currentStandaloneTags: tags };
-  const uri = URI().search(displayFiltersToQuery(filters));
+  const params = { ...getDisplayQueryParams(queryString), currentStandaloneTags: tags };
+  const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
 
 export const toggleStandaloneTagQuery = (char, queryString) => {
-  const filters = getFilters(queryString);
-  const toggledFilters = _.xor(filters.currentStandaloneTags, [char]);
-  const uri = URI().search(displayFiltersToQuery({ ...filters, currentStandaloneTags: toggledFilters }));
+  const params = getDisplayQueryParams(queryString);
+  const toggledFilters = _.xor(params.currentStandaloneTags, [char]);
+  const uri = URI().search(displayParamsToQuery({ ...params, currentStandaloneTags: toggledFilters }));
   return uri.search();
 }
 
-const displayFiltersToQuery = filters => _.pickBy({
-  ...filters.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(filters.currentMainChars) },
-  ...filters.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(filters.currentVsChars) },
-  ...filters.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(filters.currentStages) },
-  ...filters.currentStandaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(filters.currentStandaloneTags) },
+const displayParamsToQuery = params => _.pickBy({
+  ...params.currentSort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[params.currentSort] },
+  ...params.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(params.currentMainChars) },
+  ...params.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(params.currentVsChars) },
+  ...params.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(params.currentStages) },
+  ...params.currentStandaloneTags && { [query.QUERY_TAGS]: getTagFilterQuery(params.currentStandaloneTags) },
 }, _.identity);

--- a/client/src/uri_util.js
+++ b/client/src/uri_util.js
@@ -16,6 +16,8 @@ export const getDisplayQueryParams = queryString => {
   const queryMap = URI(queryString).query(true);
   return {
     ...queryMap[query.QUERY_SORT] && { currentSort: getSort(queryString) },
+    ...queryMap[query.QUERY_LIMIT] && { currentPageSize: getPageSize(queryString) },
+    ...queryMap[query.QUERY_OFFSET] && { currentOffset: getOffset(queryString) },
     ...queryMap[query.QUERY_MAIN_CHARS] && { currentMainChars: getCharFilters(queryMap[query.QUERY_MAIN_CHARS]) },
     ...queryMap[query.QUERY_VS_CHARS] && { currentVsChars: getCharFilters(queryMap[query.QUERY_VS_CHARS]) },
     ...queryMap[query.QUERY_STAGES] && { currentStages: getStageFilters(queryMap[query.QUERY_STAGES]) },
@@ -27,8 +29,28 @@ export const getSort = queryString => {
   return PARAM_TO_CLIENT_SORT[URI(queryString).query(true)[query.QUERY_SORT]];
 };
 
+export const getPageSize = queryString => {
+  return parseInt(URI(queryString).query(true)[query.QUERY_LIMIT], 10);
+};
+
+export const getOffset = queryString => {
+  return parseInt(URI(queryString).query(true)[query.QUERY_OFFSET], 10);
+};
+
 export const setSortQuery = (sort, queryString) => {
   const params = { ...getDisplayQueryParams(queryString), currentSort: sort };
+  const uri = URI().search(displayParamsToQuery(params));
+  return uri.search();
+}
+
+export const setPageSizeQuery = (pageSize, queryString) => {
+  const params = { ...getDisplayQueryParams(queryString), currentPageSize: pageSize };
+  const uri = URI().search(displayParamsToQuery(params));
+  return uri.search();
+}
+
+export const setOffsetQuery = (offset, queryString) => {
+  const params = { ...getDisplayQueryParams(queryString), currentOffset: offset };
   const uri = URI().search(displayParamsToQuery(params));
   return uri.search();
 }
@@ -87,6 +109,8 @@ export const toggleStandaloneTagQuery = (char, queryString) => {
 
 const displayParamsToQuery = params => _.pickBy({
   ...params.currentSort && { [query.QUERY_SORT]: CLIENT_SORT_TO_PARAM[params.currentSort] },
+  ...params.currentPageSize && { [query.QUERY_LIMIT]: params.currentPageSize },
+  ...params.currentOffset && { [query.QUERY_OFFSET]: params.currentOffset },
   ...params.currentMainChars && { [query.QUERY_MAIN_CHARS]: getCharFilterQuery(params.currentMainChars) },
   ...params.currentVsChars && { [query.QUERY_VS_CHARS]: getCharFilterQuery(params.currentVsChars) },
   ...params.currentStages && { [query.QUERY_STAGES]: getStageFilterQuery(params.currentStages) },


### PR DESCRIPTION
Sort, offset, and page size are now routed on the client. This lets us simplify some stuff, like api_client can now just use the URL querystring directly when fetching Bits.