### PR TITLE
Add support for css modules, where classes (mostly) are not global.

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Button } from 'react-bootstrap';
 import { Route, Switch } from 'react-router-dom';
-import './App.sass';
+import styles from './App.sass';
 import BitPage from './BitPage';
 import Home from './Home';
 
@@ -9,14 +9,14 @@ class App extends Component {
   render() {
     return (
       <div>
-        <div className='App'>
-          <div className='App-header'>
+        <div className={styles.container}>
+          <div className={styles.header}>
             <h2>Welcome to SmashBits!</h2>
             <a href='http://localhost:3001/login/twitter'>
               <Button>Log in with Twitter</Button>
             </a>
           </div>
-          <p className='App-intro'>
+          <p className={styles.intro}>
             SmashBits is a place to collaborate on and organize game knowledge
             in a central, public place.
           </p>

--- a/client/src/App.sass
+++ b/client/src/App.sass
@@ -1,21 +1,21 @@
-.App 
+.container
   text-align: center
 
-.App-logo 
+.logo
   animation: App-logo-spin infinite 20s linear
   height: 80px
 
-.App-header 
+.header
   background-color: #222
   height: 150px
   padding: 20px
   color: white
 
-.App-intro 
+.intro
   font-size: large
 
-@keyframes App-logo-spin 
-  from 
+@keyframes App-logo-spin
+  from
     transform: rotate(0deg)
   to
     transform: rotate(360deg)

--- a/client/src/Bit.jsx
+++ b/client/src/Bit.jsx
@@ -3,21 +3,22 @@ import { Map } from 'immutable';
 import { USER_UPVOTE, USER_DOWNVOTE } from './reducer';
 import { Panel, Button } from 'react-bootstrap';
 import { Link } from "react-router-dom";
+import styles from './Bit.sass';
 import BitTagPills from './BitTagPills';
 
 export default function Bit(props) {
   const { bit = new Map(), upvote, downvote } = props;
   const header = (
-      <h3>
-        <Button bsStyle={getUpvoteButtonStyle(bit)} className="thumbs-up-button" onClick={() => upvote(bit.get('postId'))}>
-          <span className="glyphicon glyphicon-thumbs-up" />
-        </Button>
-        {bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0)}
-        <Button bsStyle={getDownvoteButtonStyle(bit)} className="thumbs-down-button" onClick={() => downvote(bit.get('postId'))}>
-          <span className="glyphicon glyphicon-thumbs-down" />
-        </Button>
-        {bit.get('title')}
-      </h3>
+    <h3>
+      <Button bsStyle={getUpvoteButtonStyle(bit)} className="thumbs-up-button" onClick={() => upvote(bit.get('postId'))}>
+        <span className="glyphicon glyphicon-thumbs-up" />
+      </Button>
+      {bit.get('upvotes', 0) - bit.get('downvotes', 0) + bit.get('userVote', 0)}
+      <Button bsStyle={getDownvoteButtonStyle(bit)} className="thumbs-down-button" onClick={() => downvote(bit.get('postId'))}>
+        <span className="glyphicon glyphicon-thumbs-down" />
+      </Button>
+      <span className={styles.title}>{bit.get('title')}</span>
+    </h3>
   );
   return (
     <Panel header={header}>
@@ -30,7 +31,7 @@ export default function Bit(props) {
         </p>
         {bit.get('content')}
         <p>
-          <Link to={ '/bits/' + bit.get('postId') }>permalink</Link>
+          <Link to={'/bits/' + bit.get('postId')}>permalink</Link>
         </p>
       </div>
     </Panel>
@@ -38,7 +39,7 @@ export default function Bit(props) {
 }
 
 const getDownvoteButtonStyle = bit =>
-    bit.get('userVote') === USER_DOWNVOTE ? 'danger' : 'default';
+  bit.get('userVote') === USER_DOWNVOTE ? 'danger' : 'default';
 
 const getUpvoteButtonStyle = bit =>
-    bit.get('userVote') === USER_UPVOTE ? 'success' : 'default';
+  bit.get('userVote') === USER_UPVOTE ? 'success' : 'default';

--- a/client/src/Bit.sass
+++ b/client/src/Bit.sass
@@ -1,0 +1,2 @@
+.title
+  padding-left: 10px

--- a/client/src/api_client.ts
+++ b/client/src/api_client.ts
@@ -20,7 +20,7 @@ const BASE_URI =
 const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
 // Set this to true in development to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
+const USE_FAKE_CLIENT = true || process.env.NODE_ENV === 'development';
 
 export function fetchBits(dispatch: Function) {
   let fetchPromise;

--- a/client/src/api_client.ts
+++ b/client/src/api_client.ts
@@ -20,7 +20,7 @@ const BASE_URI =
 const BITS_PATH = '/bits';
 const COMMENTS_PATH = '/comments';
 // Set this to true in development to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = true || process.env.NODE_ENV === 'development';
+const USE_FAKE_CLIENT = false && process.env.NODE_ENV === 'development';
 
 export function fetchBits(dispatch: Function) {
   let fetchPromise;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -26,7 +26,12 @@ module.exports = {
         test: /\.s[ac]ss$/i,
         use: [
           'style-loader',
-          'css-loader',
+          {
+            loader: "css-loader",
+            options: {
+              modules: true,
+            }
+          },
           'sass-loader',
         ],
       },


### PR DESCRIPTION
Also rename some jsx files to use the extension .jsx so VS Code is happy.
A few style suggestions done by vs code, maybe we can commit some default styling options in a future PR.