### PR TITLE
Fix dotenv parsing.

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,8 +1,5 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
-# env variables
-.env
-
 # dependencies
 /node_modules
 

--- a/client/src/CreateBitButton.jsx
+++ b/client/src/CreateBitButton.jsx
@@ -3,6 +3,7 @@ import { Button } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import * as actionCreators from './action_creators';
 import CreateBitModal from './CreateBitModal';
+import LoginButton from './LoginButton';
 
 class CreateBitButton extends Component {
 
@@ -26,21 +27,26 @@ class CreateBitButton extends Component {
   }
 
   render() {
-    const { filtering, createBit } = this.props;
-    return ([
-      <Button bsStyle="danger" onClick={this.show} key="create-bit-button">
-        Create new bit
-      </Button>,
-      <CreateBitModal show={this.state.show} createBit={createBit} onHide={this.hide} key="create-bit-modal"
-        allChars={filtering.get('chars')}
-        allStages={filtering.get('stages')}
-        allTags={filtering.get('standaloneTags')} />
-    ]);
+    const { filtering, profile, createBit } = this.props;
+    if (profile) {
+      return ([
+        <Button bsStyle="danger" onClick={this.show} key="create-bit-button">
+          Create new bit
+        </Button>,
+        <CreateBitModal show={this.state.show} createBit={createBit} onHide={this.hide} key="create-bit-modal"
+          allChars={filtering.get('chars')}
+          allStages={filtering.get('stages')}
+          allTags={filtering.get('standaloneTags')} />
+      ]);
+    } else {
+      return <LoginButton bsStyle="danger" loginText="Log in to create bits" />;
+    }
   };
 }
 
 const mapStateToProps = state => ({
-  filtering: state.get('filtering')
+  filtering: state.get('filtering'),
+  profile: state.get('profile'),
 });
 
 export default connect(mapStateToProps, actionCreators)(CreateBitButton);

--- a/client/src/LoginButton.jsx
+++ b/client/src/LoginButton.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { initTwitterLogin } from './api_client';
 
 const LoginButton = props => {
-  const { profile } = props;
+  const { profile, bsStyle = 'default', loginText = 'Log in with Twitter' } = props;
   if (profile) {
     return (
       <Label>
@@ -13,12 +13,12 @@ const LoginButton = props => {
     );
   } else {
     return (
-      <Button onClick={() => initTwitterLogin()}>Log in with Twitter</Button>
+      <Button bsStyle={bsStyle} onClick={() => initTwitterLogin()}>{loginText}</Button>
     );
   }
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   profile: state.get('profile'),
 });
 

--- a/client/src/api_client.ts
+++ b/client/src/api_client.ts
@@ -23,7 +23,7 @@ const OAUTH_PATH = '/login';
 const TWITTER_PATH = '/twitter';
 const PROFILE_PATH = '/profile';
 // Set this to true in .env to use local, fake data instead of making any RPCs.
-const USE_FAKE_CLIENT = process.env.USE_FAKE_API_CLIENT && process.env.NODE_ENV === 'development';
+const USE_FAKE_CLIENT = (process.env.USE_FAKE_API_CLIENT === 'true') && process.env.NODE_ENV === 'development';
 
 export function fetchBits(dispatch: Function) {
   let fetchPromise;


### PR DESCRIPTION
These variables are treated as strings, not booleans.

As a side note, we might want to ignore changes to .env with `git update-index --skip-worktree client/.env`. Looks like adding it to .gitignore doesn't actually work once the file is already tracked by git. I'll add this to the documentation.